### PR TITLE
Fix: Correct failureDetails type for Prisma

### DIFF
--- a/src/app/api/agent/mission/route.ts
+++ b/src/app/api/agent/mission/route.ts
@@ -60,6 +60,25 @@ export async function POST(req: NextRequest) {
         // Explicitly construct the object for Prisma's TaskCreateManyMissionInput-like type
         // This structure is Omit<PrismaTask, 'id' | 'missionId' | 'createdAt' | 'updatedAt' | 'mission'>
         // PrismaTask fields: description, status, result?, retries, failureDetails?, validationOutcome?
+        let prismaFailureDetails: { reason: string } | undefined = undefined;
+        if (typeof t.failureDetails === 'string' && t.failureDetails.trim() !== '') {
+          prismaFailureDetails = { reason: t.failureDetails };
+        } else if (typeof t.failureDetails === 'object' && t.failureDetails !== null) {
+          // If it's already an object, assume it's correctly structured or Prisma will handle/validate
+          // Or, if specific structure is known for objects, adapt here.
+          // For now, let's pass it if it's an object. Consider if it needs stringification
+          // based on Prisma schema. Given the error, Prisma wants an object, not a stringified object.
+          // So, if t.failureDetails is { foo: "bar" }, JSON.stringify would make it "{"foo":"bar"}"
+          // which is not what's desired.
+          // This branch might need refinement if t.failureDetails can be various object types.
+          // However, the original issue mentioned "string | null" becoming the problem.
+          // The most direct fix for "string | null" is to handle the string case to become an object,
+          // and null/undefined to become undefined.
+          // If t.failureDetails is an object, it's assumed to be in the correct shape for Prisma.
+          prismaFailureDetails = t.failureDetails as any; // Cast to any if unsure about specific object structure
+        }
+        // If t.failureDetails was null, undefined, or empty string, prismaFailureDetails remains undefined.
+
         return {
           description: t.description,
           status: t.status,
@@ -67,7 +86,7 @@ export async function POST(req: NextRequest) {
           result: t.result !== undefined ? JSON.stringify(t.result) : null,
           // Retries should default to 0 if not present from decomposer, as Prisma expects an Int.
           retries: t.retries !== undefined ? t.retries : 0,
-          failureDetails: t.failureDetails !== undefined ? JSON.stringify(t.failureDetails) : null,
+          failureDetails: prismaFailureDetails, // Use the new variable
           validationOutcome: t.validationOutcome !== undefined ? JSON.stringify(t.validationOutcome) : null,
         };
       });


### PR DESCRIPTION
The `failureDetails` field in `decomposedTasksData` was being assigned as a stringified JSON or null. Prisma, however, expects this field to be a direct JSON object (e.g., { reason: "some error" }) or undefined.

This commit modifies the transformation of `tasksFromDecomposer` data to ensure that:
- If `t.failureDetails` is a non-empty string, it is wrapped into an object: `{ reason: t.failureDetails }`.
- If `t.failureDetails` is already an object, it is passed through as is.
- If `t.failureDetails` is null, undefined, or an empty string, the `failureDetails` field for Prisma becomes `undefined`.

This change resolves the TypeScript type error where `string | null` was not assignable to the expected Prisma type for `failureDetails`.